### PR TITLE
Change react-native-touch-id to expo-local-auth

### DIFF
--- a/dist/src/PinCodeEnter.js
+++ b/dist/src/PinCodeEnter.js
@@ -7,226 +7,138 @@ const async_storage_1 = require("@react-native-community/async-storage");
 const React = require("react");
 const react_native_1 = require("react-native");
 const Keychain = require("react-native-keychain");
-const react_native_touch_id_1 = require("react-native-touch-id");
-const expo_local_authentication = require("expo-local-authentication");
+const LocalAuthentication = require("expo-local-authentication");
 class PinCodeEnter extends React.PureComponent {
-	constructor(props) {
-		super(props);
-		this.keyChainResult = undefined;
-		this.endProcess = async (pinCode) => {
-			if (!!this.props.endProcessFunction) {
-				this.props.endProcessFunction(pinCode);
-			} else {
-				let pinValidOverride = undefined;
-				if (this.props.handleResult) {
-					pinValidOverride = await Promise.resolve(
-						this.props.handleResult(pinCode)
-					);
-				}
-				this.setState({ pinCodeStatus: utils_1.PinResultStatus.initial });
-				this.props.changeInternalStatus(utils_1.PinResultStatus.initial);
-				const pinAttemptsStr = await async_storage_1.default.getItem(
-					this.props.pinAttemptsAsyncStorageName
-				);
-				let pinAttempts = pinAttemptsStr ? +pinAttemptsStr : 0;
-				const pin = this.props.storedPin || this.keyChainResult;
-				if (
-					pinValidOverride !== undefined ? pinValidOverride : pin === pinCode
-				) {
-					this.setState({ pinCodeStatus: utils_1.PinResultStatus.success });
-					async_storage_1.default.multiRemove([
-						this.props.pinAttemptsAsyncStorageName,
-						this.props.timePinLockedAsyncStorageName,
-					]);
-					this.props.changeInternalStatus(utils_1.PinResultStatus.success);
-					if (!!this.props.finishProcess) this.props.finishProcess(pinCode);
-				} else {
-					pinAttempts++;
-					if (
-						+pinAttempts >= this.props.maxAttempts &&
-						!this.props.disableLockScreen
-					) {
-						await async_storage_1.default.setItem(
-							this.props.timePinLockedAsyncStorageName,
-							new Date().toISOString()
-						);
-						this.setState({
-							locked: true,
-							pinCodeStatus: utils_1.PinResultStatus.locked,
-						});
-						this.props.changeInternalStatus(utils_1.PinResultStatus.locked);
-					} else {
-						await async_storage_1.default.setItem(
-							this.props.pinAttemptsAsyncStorageName,
-							pinAttempts.toString()
-						);
-						this.setState({ pinCodeStatus: utils_1.PinResultStatus.failure });
-						this.props.changeInternalStatus(utils_1.PinResultStatus.failure);
-					}
-					if (this.props.onFail) {
-						await delay_1.default(1500);
-						this.props.onFail(pinAttempts);
-					}
-				}
-			}
-		};
-		this.state = {
-			pinCodeStatus: utils_1.PinResultStatus.initial,
-			locked: false,
-		};
-		this.endProcess = this.endProcess.bind(this);
-		this.launchTouchID = this.launchTouchID.bind(this);
-		if (!this.props.storedPin) {
-			Keychain.getInternetCredentials(
-				this.props.pinCodeKeychainName,
-				utils_1.noBiometricsConfig
-			)
-				.then((result) => {
-					this.keyChainResult = (result && result.password) || undefined;
-				})
-				.catch((error) => {
-					console.log("PinCodeEnter: ", error);
-				});
-		}
-	}
-	componentDidMount() {
-		if (!this.props.touchIDDisabled) this.triggerTouchID();
-	}
-	componentDidUpdate(prevProps, prevState, prevContext) {
-		if (prevProps.pinStatusExternal !== this.props.pinStatusExternal) {
-			this.setState({ pinCodeStatus: this.props.pinStatusExternal });
-		}
-		if (prevProps.touchIDDisabled && !this.props.touchIDDisabled) {
-			this.triggerTouchID();
-		}
-	}
-	triggerTouchID() {
-		!!expo_local_authentication
-			.hasHardwareAsync()
-			.then(() => {
-				setTimeout(() => {
-					this.launchTouchID();
-				});
-			})
-			.catch((error) => {
-				console.warn("TouchID error", error);
-			});
-	}
-	async launchTouchID() {
-		// const optionalConfigObject = {
-		// 	imageColor: "#e00606",
-		// 	imageErrorColor: "#ff0000",
-		// 	sensorDescription: "Touch sensor",
-		// 	sensorErrorDescription: "Failed",
-		// 	cancelText: this.props.textCancelButtonTouchID || "Cancel",
-		// 	fallbackLabel: "Show Passcode",
-		// 	unifiedErrors: false,
-		// 	passcodeFallback: this.props.passcodeFallback,
-		// };
-		try {
-			await expo_local_authentication
-				.authenticateAsync({
-					promptMessage: this.props.touchIDSentence,
-					fallbackLabel: "Show Passcode",
-					cancelLabel: this.props.textCancelButtonTouchID || "Cancel",
-					// Object.assign({}, optionalConfigObject, {
-					// 	title: this.props.touchIDTitle,
-					// })
-				})
-				.then((success) => {
-					this.endProcess(this.props.storedPin || this.keyChainResult);
-				});
-		} catch (e) {
-			if (!!this.props.callbackErrorTouchId) {
-				this.props.callbackErrorTouchId(e);
-			} else {
-				console.log("TouchID error", e);
-			}
-		}
-	}
-	render() {
-		const pin = this.props.storedPin || this.keyChainResult;
-		return React.createElement(
-			react_native_1.View,
-			{ style: [styles.container, this.props.styleContainer] },
-			React.createElement(PinCode_1.default, {
-				alphabetCharsVisible: this.props.alphabetCharsVisible,
-				buttonDeleteComponent: this.props.buttonDeleteComponent || null,
-				buttonDeleteText: this.props.buttonDeleteText,
-				buttonNumberComponent: this.props.buttonNumberComponent || null,
-				colorCircleButtons: this.props.colorCircleButtons,
-				colorPassword: this.props.colorPassword || undefined,
-				colorPasswordEmpty: this.props.colorPasswordEmpty,
-				colorPasswordError: this.props.colorPasswordError || undefined,
-				customBackSpaceIcon: this.props.customBackSpaceIcon,
-				emptyColumnComponent: this.props.emptyColumnComponent,
-				endProcess: this.endProcess,
-				launchTouchID: this.launchTouchID,
-				getCurrentLength: this.props.getCurrentLength,
-				iconButtonDeleteDisabled: this.props.iconButtonDeleteDisabled,
-				numbersButtonOverlayColor:
-					this.props.numbersButtonOverlayColor || undefined,
-				passwordComponent: this.props.passwordComponent || null,
-				passwordLength: this.props.passwordLength || 4,
-				pinCodeStatus: this.state.pinCodeStatus,
-				pinCodeVisible: this.props.pinCodeVisible,
-				previousPin: pin,
-				sentenceTitle: this.props.title,
-				status: PinCode_1.PinStatus.enter,
-				styleAlphabet: this.props.styleAlphabet,
-				styleButtonCircle: this.props.styleButtonCircle,
-				styleCircleHiddenPassword: this.props.styleCircleHiddenPassword,
-				styleCircleSizeEmpty: this.props.styleCircleSizeEmpty,
-				styleCircleSizeFull: this.props.styleCircleSizeFull,
-				styleColumnButtons: this.props.styleColumnButtons,
-				styleColumnDeleteButton: this.props.styleColumnDeleteButton,
-				styleColorButtonTitle: this.props.styleColorButtonTitle,
-				styleColorButtonTitleSelected: this.props.styleColorButtonTitleSelected,
-				styleColorSubtitle: this.props.styleColorSubtitle,
-				styleColorSubtitleError: this.props.styleColorSubtitleError,
-				styleColorTitle: this.props.styleColorTitle,
-				styleColorTitleError: this.props.styleColorTitleError,
-				styleContainer: this.props.styleContainerPinCode,
-				styleDeleteButtonColorHideUnderlay: this.props
-					.styleDeleteButtonColorHideUnderlay,
-				styleDeleteButtonColorShowUnderlay: this.props
-					.styleDeleteButtonColorShowUnderlay,
-				styleDeleteButtonIcon: this.props.styleDeleteButtonIcon,
-				styleDeleteButtonSize: this.props.styleDeleteButtonSize,
-				styleDeleteButtonText: this.props.styleDeleteButtonText,
-				styleEmptyColumn: this.props.styleEmptyColumn,
-				stylePinCodeCircle: this.props.stylePinCodeCircle,
-				styleRowButtons: this.props.styleRowButtons,
-				styleTextButton: this.props.styleTextButton,
-				styleTextSubtitle: this.props.styleTextSubtitle,
-				styleTextTitle: this.props.styleTextTitle,
-				styleViewTitle: this.props.styleViewTitle,
-				subtitle: this.props.subtitle,
-				subtitleComponent: this.props.subtitleComponent || null,
-				subtitleError: this.props.subtitleError || "Please try again",
-				textPasswordVisibleFamily: this.props.textPasswordVisibleFamily,
-				textPasswordVisibleSize: this.props.textPasswordVisibleSize,
-				titleAttemptFailed:
-					this.props.titleAttemptFailed || "Incorrect PIN Code",
-				titleComponent: this.props.titleComponent || null,
-				titleConfirmFailed:
-					this.props.titleConfirmFailed || "Your entries did not match",
-				vibrationEnabled: this.props.vibrationEnabled,
-				delayBetweenAttempts: this.props.delayBetweenAttempts,
-				callbackError: this.props.callbackError,
-			})
-		);
-	}
+    constructor(props) {
+        super(props);
+        this.keyChainResult = undefined;
+        this.endProcess = async (pinCode) => {
+            if (!!this.props.endProcessFunction) {
+                this.props.endProcessFunction(pinCode);
+            }
+            else {
+                let pinValidOverride = undefined;
+                if (this.props.handleResult) {
+                    pinValidOverride = await Promise.resolve(this.props.handleResult(pinCode));
+                }
+                this.setState({ pinCodeStatus: utils_1.PinResultStatus.initial });
+                this.props.changeInternalStatus(utils_1.PinResultStatus.initial);
+                const pinAttemptsStr = await async_storage_1.default.getItem(this.props.pinAttemptsAsyncStorageName);
+                let pinAttempts = pinAttemptsStr ? +pinAttemptsStr : 0;
+                const pin = this.props.storedPin || this.keyChainResult;
+                if (pinValidOverride !== undefined ? pinValidOverride : pin === pinCode) {
+                    this.setState({ pinCodeStatus: utils_1.PinResultStatus.success });
+                    async_storage_1.default.multiRemove([
+                        this.props.pinAttemptsAsyncStorageName,
+                        this.props.timePinLockedAsyncStorageName,
+                    ]);
+                    this.props.changeInternalStatus(utils_1.PinResultStatus.success);
+                    if (!!this.props.finishProcess)
+                        this.props.finishProcess(pinCode);
+                }
+                else {
+                    pinAttempts++;
+                    if (+pinAttempts >= this.props.maxAttempts &&
+                        !this.props.disableLockScreen) {
+                        await async_storage_1.default.setItem(this.props.timePinLockedAsyncStorageName, new Date().toISOString());
+                        this.setState({
+                            locked: true,
+                            pinCodeStatus: utils_1.PinResultStatus.locked,
+                        });
+                        this.props.changeInternalStatus(utils_1.PinResultStatus.locked);
+                    }
+                    else {
+                        await async_storage_1.default.setItem(this.props.pinAttemptsAsyncStorageName, pinAttempts.toString());
+                        this.setState({ pinCodeStatus: utils_1.PinResultStatus.failure });
+                        this.props.changeInternalStatus(utils_1.PinResultStatus.failure);
+                    }
+                    if (this.props.onFail) {
+                        await delay_1.default(1500);
+                        this.props.onFail(pinAttempts);
+                    }
+                }
+            }
+        };
+        this.state = { pinCodeStatus: utils_1.PinResultStatus.initial, locked: false };
+        this.endProcess = this.endProcess.bind(this);
+        this.launchTouchID = this.launchTouchID.bind(this);
+        if (!this.props.storedPin) {
+            Keychain.getInternetCredentials(this.props.pinCodeKeychainName, utils_1.noBiometricsConfig)
+                .then((result) => {
+                this.keyChainResult = (result && result.password) || undefined;
+            })
+                .catch((error) => {
+                console.log("PinCodeEnter: ", error);
+            });
+        }
+    }
+    componentDidMount() {
+        if (!this.props.touchIDDisabled)
+            this.triggerTouchID();
+    }
+    componentDidUpdate(prevProps, prevState, prevContext) {
+        if (prevProps.pinStatusExternal !== this.props.pinStatusExternal) {
+            this.setState({ pinCodeStatus: this.props.pinStatusExternal });
+        }
+        if (prevProps.touchIDDisabled && !this.props.touchIDDisabled) {
+            this.triggerTouchID();
+        }
+    }
+    triggerTouchID() {
+        LocalAuthentication.hasHardwareAsync()
+            .then(() => {
+            setTimeout(() => {
+                this.launchTouchID();
+            });
+        })
+            .catch((error) => {
+            console.warn("TouchID error", error);
+        });
+    }
+    async launchTouchID() {
+        // const optionalConfigObject = {
+        // 	imageColor: "#e00606",
+        // 	imageErrorColor: "#ff0000",
+        // 	sensorDescription: "Touch sensor",
+        // 	sensorErrorDescription: "Failed",
+        // 	cancelText: this.props.textCancelButtonTouchID || "Cancel",
+        // 	fallbackLabel: "Show Passcode",
+        // 	unifiedErrors: false,
+        // 	passcodeFallback: this.props.passcodeFallback,
+        // };
+        try {
+            await LocalAuthentication.authenticateAsync({
+                promptMessage: this.props.touchIDSentence,
+                fallbackLabel: "Show Passcode",
+                cancelLabel: this.props.textCancelButtonTouchID || "Cancel",
+            }).then((success) => {
+                this.endProcess(this.props.storedPin || this.keyChainResult);
+            });
+        }
+        catch (e) {
+            if (!!this.props.callbackErrorTouchId) {
+                this.props.callbackErrorTouchId(e);
+            }
+            else {
+                console.log("TouchID error", e);
+            }
+        }
+    }
+    render() {
+        const pin = this.props.storedPin || this.keyChainResult;
+        return (React.createElement(react_native_1.View, { style: [styles.container, this.props.styleContainer] },
+            React.createElement(PinCode_1.default, { alphabetCharsVisible: this.props.alphabetCharsVisible, buttonDeleteComponent: this.props.buttonDeleteComponent || null, buttonDeleteText: this.props.buttonDeleteText, buttonNumberComponent: this.props.buttonNumberComponent || null, colorCircleButtons: this.props.colorCircleButtons, colorPassword: this.props.colorPassword || undefined, colorPasswordEmpty: this.props.colorPasswordEmpty, colorPasswordError: this.props.colorPasswordError || undefined, customBackSpaceIcon: this.props.customBackSpaceIcon, emptyColumnComponent: this.props.emptyColumnComponent, endProcess: this.endProcess, launchTouchID: this.launchTouchID, getCurrentLength: this.props.getCurrentLength, iconButtonDeleteDisabled: this.props.iconButtonDeleteDisabled, numbersButtonOverlayColor: this.props.numbersButtonOverlayColor || undefined, passwordComponent: this.props.passwordComponent || null, passwordLength: this.props.passwordLength || 4, pinCodeStatus: this.state.pinCodeStatus, pinCodeVisible: this.props.pinCodeVisible, previousPin: pin, sentenceTitle: this.props.title, status: PinCode_1.PinStatus.enter, styleAlphabet: this.props.styleAlphabet, styleButtonCircle: this.props.styleButtonCircle, styleCircleHiddenPassword: this.props.styleCircleHiddenPassword, styleCircleSizeEmpty: this.props.styleCircleSizeEmpty, styleCircleSizeFull: this.props.styleCircleSizeFull, styleColumnButtons: this.props.styleColumnButtons, styleColumnDeleteButton: this.props.styleColumnDeleteButton, styleColorButtonTitle: this.props.styleColorButtonTitle, styleColorButtonTitleSelected: this.props.styleColorButtonTitleSelected, styleColorSubtitle: this.props.styleColorSubtitle, styleColorSubtitleError: this.props.styleColorSubtitleError, styleColorTitle: this.props.styleColorTitle, styleColorTitleError: this.props.styleColorTitleError, styleContainer: this.props.styleContainerPinCode, styleDeleteButtonColorHideUnderlay: this.props.styleDeleteButtonColorHideUnderlay, styleDeleteButtonColorShowUnderlay: this.props.styleDeleteButtonColorShowUnderlay, styleDeleteButtonIcon: this.props.styleDeleteButtonIcon, styleDeleteButtonSize: this.props.styleDeleteButtonSize, styleDeleteButtonText: this.props.styleDeleteButtonText, styleEmptyColumn: this.props.styleEmptyColumn, stylePinCodeCircle: this.props.stylePinCodeCircle, styleRowButtons: this.props.styleRowButtons, styleTextButton: this.props.styleTextButton, styleTextSubtitle: this.props.styleTextSubtitle, styleTextTitle: this.props.styleTextTitle, styleViewTitle: this.props.styleViewTitle, subtitle: this.props.subtitle, subtitleComponent: this.props.subtitleComponent || null, subtitleError: this.props.subtitleError || "Please try again", textPasswordVisibleFamily: this.props.textPasswordVisibleFamily, textPasswordVisibleSize: this.props.textPasswordVisibleSize, titleAttemptFailed: this.props.titleAttemptFailed || "Incorrect PIN Code", titleComponent: this.props.titleComponent || null, titleConfirmFailed: this.props.titleConfirmFailed || "Your entries did not match", vibrationEnabled: this.props.vibrationEnabled, delayBetweenAttempts: this.props.delayBetweenAttempts, callbackError: this.props.callbackError })));
+    }
 }
 PinCodeEnter.defaultProps = {
-	passcodeFallback: true,
-	styleContainer: null,
+    passcodeFallback: true,
+    styleContainer: null,
 };
 const styles = react_native_1.StyleSheet.create({
-	container: {
-		flex: 1,
-		justifyContent: "center",
-		alignItems: "center",
-	},
+    container: {
+        flex: 1,
+        justifyContent: "center",
+        alignItems: "center",
+    },
 });
 exports.default = PinCodeEnter;

--- a/dist/src/PinCodeEnter.js
+++ b/dist/src/PinCodeEnter.js
@@ -102,7 +102,7 @@ class PinCodeEnter extends React.PureComponent {
 	}
 	triggerTouchID() {
 		!!expo_local_authentication
-			.hasHardwareAsync()()
+			.hasHardwareAsync()
 			.then(() => {
 				setTimeout(() => {
 					this.launchTouchID();

--- a/dist/src/PinCodeEnter.js
+++ b/dist/src/PinCodeEnter.js
@@ -8,136 +8,225 @@ const React = require("react");
 const react_native_1 = require("react-native");
 const Keychain = require("react-native-keychain");
 const react_native_touch_id_1 = require("react-native-touch-id");
+const expo_local_authentication = require("expo-local-authentication");
 class PinCodeEnter extends React.PureComponent {
-    constructor(props) {
-        super(props);
-        this.keyChainResult = undefined;
-        this.endProcess = async (pinCode) => {
-            if (!!this.props.endProcessFunction) {
-                this.props.endProcessFunction(pinCode);
-            }
-            else {
-                let pinValidOverride = undefined;
-                if (this.props.handleResult) {
-                    pinValidOverride = await Promise.resolve(this.props.handleResult(pinCode));
-                }
-                this.setState({ pinCodeStatus: utils_1.PinResultStatus.initial });
-                this.props.changeInternalStatus(utils_1.PinResultStatus.initial);
-                const pinAttemptsStr = await async_storage_1.default.getItem(this.props.pinAttemptsAsyncStorageName);
-                let pinAttempts = pinAttemptsStr ? +pinAttemptsStr : 0;
-                const pin = this.props.storedPin || this.keyChainResult;
-                if (pinValidOverride !== undefined ? pinValidOverride : pin === pinCode) {
-                    this.setState({ pinCodeStatus: utils_1.PinResultStatus.success });
-                    async_storage_1.default.multiRemove([
-                        this.props.pinAttemptsAsyncStorageName,
-                        this.props.timePinLockedAsyncStorageName,
-                    ]);
-                    this.props.changeInternalStatus(utils_1.PinResultStatus.success);
-                    if (!!this.props.finishProcess)
-                        this.props.finishProcess(pinCode);
-                }
-                else {
-                    pinAttempts++;
-                    if (+pinAttempts >= this.props.maxAttempts &&
-                        !this.props.disableLockScreen) {
-                        await async_storage_1.default.setItem(this.props.timePinLockedAsyncStorageName, new Date().toISOString());
-                        this.setState({
-                            locked: true,
-                            pinCodeStatus: utils_1.PinResultStatus.locked,
-                        });
-                        this.props.changeInternalStatus(utils_1.PinResultStatus.locked);
-                    }
-                    else {
-                        await async_storage_1.default.setItem(this.props.pinAttemptsAsyncStorageName, pinAttempts.toString());
-                        this.setState({ pinCodeStatus: utils_1.PinResultStatus.failure });
-                        this.props.changeInternalStatus(utils_1.PinResultStatus.failure);
-                    }
-                    if (this.props.onFail) {
-                        await delay_1.default(1500);
-                        this.props.onFail(pinAttempts);
-                    }
-                }
-            }
-        };
-        this.state = { pinCodeStatus: utils_1.PinResultStatus.initial, locked: false };
-        this.endProcess = this.endProcess.bind(this);
-        this.launchTouchID = this.launchTouchID.bind(this);
-        if (!this.props.storedPin) {
-            Keychain.getInternetCredentials(this.props.pinCodeKeychainName, utils_1.noBiometricsConfig)
-                .then((result) => {
-                this.keyChainResult = (result && result.password) || undefined;
-            })
-                .catch((error) => {
-                console.log("PinCodeEnter: ", error);
-            });
-        }
-    }
-    componentDidMount() {
-        if (!this.props.touchIDDisabled)
-            this.triggerTouchID();
-    }
-    componentDidUpdate(prevProps, prevState, prevContext) {
-        if (prevProps.pinStatusExternal !== this.props.pinStatusExternal) {
-            this.setState({ pinCodeStatus: this.props.pinStatusExternal });
-        }
-        if (prevProps.touchIDDisabled && !this.props.touchIDDisabled) {
-            this.triggerTouchID();
-        }
-    }
-    triggerTouchID() {
-        !!react_native_touch_id_1.default &&
-            react_native_touch_id_1.default.isSupported()
-                .then(() => {
-                setTimeout(() => {
-                    this.launchTouchID();
-                });
-            })
-                .catch((error) => {
-                console.warn("TouchID error", error);
-            });
-    }
-    async launchTouchID() {
-        const optionalConfigObject = {
-            imageColor: "#e00606",
-            imageErrorColor: "#ff0000",
-            sensorDescription: "Touch sensor",
-            sensorErrorDescription: "Failed",
-            cancelText: this.props.textCancelButtonTouchID || "Cancel",
-            fallbackLabel: "Show Passcode",
-            unifiedErrors: false,
-            passcodeFallback: this.props.passcodeFallback,
-        };
-        try {
-            await react_native_touch_id_1.default.authenticate(this.props.touchIDSentence, Object.assign({}, optionalConfigObject, {
-                title: this.props.touchIDTitle,
-            })).then((success) => {
-                this.endProcess(this.props.storedPin || this.keyChainResult);
-            });
-        }
-        catch (e) {
-            if (!!this.props.callbackErrorTouchId) {
-                this.props.callbackErrorTouchId(e);
-            }
-            else {
-                console.log("TouchID error", e);
-            }
-        }
-    }
-    render() {
-        const pin = this.props.storedPin || this.keyChainResult;
-        return (React.createElement(react_native_1.View, { style: [styles.container, this.props.styleContainer] },
-            React.createElement(PinCode_1.default, { alphabetCharsVisible: this.props.alphabetCharsVisible, buttonDeleteComponent: this.props.buttonDeleteComponent || null, buttonDeleteText: this.props.buttonDeleteText, buttonNumberComponent: this.props.buttonNumberComponent || null, colorCircleButtons: this.props.colorCircleButtons, colorPassword: this.props.colorPassword || undefined, colorPasswordEmpty: this.props.colorPasswordEmpty, colorPasswordError: this.props.colorPasswordError || undefined, customBackSpaceIcon: this.props.customBackSpaceIcon, emptyColumnComponent: this.props.emptyColumnComponent, endProcess: this.endProcess, launchTouchID: this.launchTouchID, getCurrentLength: this.props.getCurrentLength, iconButtonDeleteDisabled: this.props.iconButtonDeleteDisabled, numbersButtonOverlayColor: this.props.numbersButtonOverlayColor || undefined, passwordComponent: this.props.passwordComponent || null, passwordLength: this.props.passwordLength || 4, pinCodeStatus: this.state.pinCodeStatus, pinCodeVisible: this.props.pinCodeVisible, previousPin: pin, sentenceTitle: this.props.title, status: PinCode_1.PinStatus.enter, styleAlphabet: this.props.styleAlphabet, styleButtonCircle: this.props.styleButtonCircle, styleCircleHiddenPassword: this.props.styleCircleHiddenPassword, styleCircleSizeEmpty: this.props.styleCircleSizeEmpty, styleCircleSizeFull: this.props.styleCircleSizeFull, styleColumnButtons: this.props.styleColumnButtons, styleColumnDeleteButton: this.props.styleColumnDeleteButton, styleColorButtonTitle: this.props.styleColorButtonTitle, styleColorButtonTitleSelected: this.props.styleColorButtonTitleSelected, styleColorSubtitle: this.props.styleColorSubtitle, styleColorSubtitleError: this.props.styleColorSubtitleError, styleColorTitle: this.props.styleColorTitle, styleColorTitleError: this.props.styleColorTitleError, styleContainer: this.props.styleContainerPinCode, styleDeleteButtonColorHideUnderlay: this.props.styleDeleteButtonColorHideUnderlay, styleDeleteButtonColorShowUnderlay: this.props.styleDeleteButtonColorShowUnderlay, styleDeleteButtonIcon: this.props.styleDeleteButtonIcon, styleDeleteButtonSize: this.props.styleDeleteButtonSize, styleDeleteButtonText: this.props.styleDeleteButtonText, styleEmptyColumn: this.props.styleEmptyColumn, stylePinCodeCircle: this.props.stylePinCodeCircle, styleRowButtons: this.props.styleRowButtons, styleTextButton: this.props.styleTextButton, styleTextSubtitle: this.props.styleTextSubtitle, styleTextTitle: this.props.styleTextTitle, styleViewTitle: this.props.styleViewTitle, subtitle: this.props.subtitle, subtitleComponent: this.props.subtitleComponent || null, subtitleError: this.props.subtitleError || "Please try again", textPasswordVisibleFamily: this.props.textPasswordVisibleFamily, textPasswordVisibleSize: this.props.textPasswordVisibleSize, titleAttemptFailed: this.props.titleAttemptFailed || "Incorrect PIN Code", titleComponent: this.props.titleComponent || null, titleConfirmFailed: this.props.titleConfirmFailed || "Your entries did not match", vibrationEnabled: this.props.vibrationEnabled, delayBetweenAttempts: this.props.delayBetweenAttempts, callbackError: this.props.callbackError })));
-    }
+	constructor(props) {
+		super(props);
+		this.keyChainResult = undefined;
+		this.endProcess = async (pinCode) => {
+			if (!!this.props.endProcessFunction) {
+				this.props.endProcessFunction(pinCode);
+			} else {
+				let pinValidOverride = undefined;
+				if (this.props.handleResult) {
+					pinValidOverride = await Promise.resolve(
+						this.props.handleResult(pinCode)
+					);
+				}
+				this.setState({ pinCodeStatus: utils_1.PinResultStatus.initial });
+				this.props.changeInternalStatus(utils_1.PinResultStatus.initial);
+				const pinAttemptsStr = await async_storage_1.default.getItem(
+					this.props.pinAttemptsAsyncStorageName
+				);
+				let pinAttempts = pinAttemptsStr ? +pinAttemptsStr : 0;
+				const pin = this.props.storedPin || this.keyChainResult;
+				if (
+					pinValidOverride !== undefined ? pinValidOverride : pin === pinCode
+				) {
+					this.setState({ pinCodeStatus: utils_1.PinResultStatus.success });
+					async_storage_1.default.multiRemove([
+						this.props.pinAttemptsAsyncStorageName,
+						this.props.timePinLockedAsyncStorageName,
+					]);
+					this.props.changeInternalStatus(utils_1.PinResultStatus.success);
+					if (!!this.props.finishProcess) this.props.finishProcess(pinCode);
+				} else {
+					pinAttempts++;
+					if (
+						+pinAttempts >= this.props.maxAttempts &&
+						!this.props.disableLockScreen
+					) {
+						await async_storage_1.default.setItem(
+							this.props.timePinLockedAsyncStorageName,
+							new Date().toISOString()
+						);
+						this.setState({
+							locked: true,
+							pinCodeStatus: utils_1.PinResultStatus.locked,
+						});
+						this.props.changeInternalStatus(utils_1.PinResultStatus.locked);
+					} else {
+						await async_storage_1.default.setItem(
+							this.props.pinAttemptsAsyncStorageName,
+							pinAttempts.toString()
+						);
+						this.setState({ pinCodeStatus: utils_1.PinResultStatus.failure });
+						this.props.changeInternalStatus(utils_1.PinResultStatus.failure);
+					}
+					if (this.props.onFail) {
+						await delay_1.default(1500);
+						this.props.onFail(pinAttempts);
+					}
+				}
+			}
+		};
+		this.state = {
+			pinCodeStatus: utils_1.PinResultStatus.initial,
+			locked: false,
+		};
+		this.endProcess = this.endProcess.bind(this);
+		this.launchTouchID = this.launchTouchID.bind(this);
+		if (!this.props.storedPin) {
+			Keychain.getInternetCredentials(
+				this.props.pinCodeKeychainName,
+				utils_1.noBiometricsConfig
+			)
+				.then((result) => {
+					this.keyChainResult = (result && result.password) || undefined;
+				})
+				.catch((error) => {
+					console.log("PinCodeEnter: ", error);
+				});
+		}
+	}
+	componentDidMount() {
+		if (!this.props.touchIDDisabled) this.triggerTouchID();
+	}
+	componentDidUpdate(prevProps, prevState, prevContext) {
+		if (prevProps.pinStatusExternal !== this.props.pinStatusExternal) {
+			this.setState({ pinCodeStatus: this.props.pinStatusExternal });
+		}
+		if (prevProps.touchIDDisabled && !this.props.touchIDDisabled) {
+			this.triggerTouchID();
+		}
+	}
+	triggerTouchID() {
+		!!expo_local_authentication
+			.hasHardwareAsync()()
+			.then(() => {
+				setTimeout(() => {
+					this.launchTouchID();
+				});
+			})
+			.catch((error) => {
+				console.warn("TouchID error", error);
+			});
+	}
+	async launchTouchID() {
+		// const optionalConfigObject = {
+		// 	imageColor: "#e00606",
+		// 	imageErrorColor: "#ff0000",
+		// 	sensorDescription: "Touch sensor",
+		// 	sensorErrorDescription: "Failed",
+		// 	cancelText: this.props.textCancelButtonTouchID || "Cancel",
+		// 	fallbackLabel: "Show Passcode",
+		// 	unifiedErrors: false,
+		// 	passcodeFallback: this.props.passcodeFallback,
+		// };
+		try {
+			await expo_local_authentication
+				.authenticateAsync({
+					promptMessage: this.props.touchIDSentence,
+					fallbackLabel: "Show Passcode",
+					cancelLabel: this.props.textCancelButtonTouchID || "Cancel",
+					// Object.assign({}, optionalConfigObject, {
+					// 	title: this.props.touchIDTitle,
+					// })
+				})
+				.then((success) => {
+					this.endProcess(this.props.storedPin || this.keyChainResult);
+				});
+		} catch (e) {
+			if (!!this.props.callbackErrorTouchId) {
+				this.props.callbackErrorTouchId(e);
+			} else {
+				console.log("TouchID error", e);
+			}
+		}
+	}
+	render() {
+		const pin = this.props.storedPin || this.keyChainResult;
+		return React.createElement(
+			react_native_1.View,
+			{ style: [styles.container, this.props.styleContainer] },
+			React.createElement(PinCode_1.default, {
+				alphabetCharsVisible: this.props.alphabetCharsVisible,
+				buttonDeleteComponent: this.props.buttonDeleteComponent || null,
+				buttonDeleteText: this.props.buttonDeleteText,
+				buttonNumberComponent: this.props.buttonNumberComponent || null,
+				colorCircleButtons: this.props.colorCircleButtons,
+				colorPassword: this.props.colorPassword || undefined,
+				colorPasswordEmpty: this.props.colorPasswordEmpty,
+				colorPasswordError: this.props.colorPasswordError || undefined,
+				customBackSpaceIcon: this.props.customBackSpaceIcon,
+				emptyColumnComponent: this.props.emptyColumnComponent,
+				endProcess: this.endProcess,
+				launchTouchID: this.launchTouchID,
+				getCurrentLength: this.props.getCurrentLength,
+				iconButtonDeleteDisabled: this.props.iconButtonDeleteDisabled,
+				numbersButtonOverlayColor:
+					this.props.numbersButtonOverlayColor || undefined,
+				passwordComponent: this.props.passwordComponent || null,
+				passwordLength: this.props.passwordLength || 4,
+				pinCodeStatus: this.state.pinCodeStatus,
+				pinCodeVisible: this.props.pinCodeVisible,
+				previousPin: pin,
+				sentenceTitle: this.props.title,
+				status: PinCode_1.PinStatus.enter,
+				styleAlphabet: this.props.styleAlphabet,
+				styleButtonCircle: this.props.styleButtonCircle,
+				styleCircleHiddenPassword: this.props.styleCircleHiddenPassword,
+				styleCircleSizeEmpty: this.props.styleCircleSizeEmpty,
+				styleCircleSizeFull: this.props.styleCircleSizeFull,
+				styleColumnButtons: this.props.styleColumnButtons,
+				styleColumnDeleteButton: this.props.styleColumnDeleteButton,
+				styleColorButtonTitle: this.props.styleColorButtonTitle,
+				styleColorButtonTitleSelected: this.props.styleColorButtonTitleSelected,
+				styleColorSubtitle: this.props.styleColorSubtitle,
+				styleColorSubtitleError: this.props.styleColorSubtitleError,
+				styleColorTitle: this.props.styleColorTitle,
+				styleColorTitleError: this.props.styleColorTitleError,
+				styleContainer: this.props.styleContainerPinCode,
+				styleDeleteButtonColorHideUnderlay: this.props
+					.styleDeleteButtonColorHideUnderlay,
+				styleDeleteButtonColorShowUnderlay: this.props
+					.styleDeleteButtonColorShowUnderlay,
+				styleDeleteButtonIcon: this.props.styleDeleteButtonIcon,
+				styleDeleteButtonSize: this.props.styleDeleteButtonSize,
+				styleDeleteButtonText: this.props.styleDeleteButtonText,
+				styleEmptyColumn: this.props.styleEmptyColumn,
+				stylePinCodeCircle: this.props.stylePinCodeCircle,
+				styleRowButtons: this.props.styleRowButtons,
+				styleTextButton: this.props.styleTextButton,
+				styleTextSubtitle: this.props.styleTextSubtitle,
+				styleTextTitle: this.props.styleTextTitle,
+				styleViewTitle: this.props.styleViewTitle,
+				subtitle: this.props.subtitle,
+				subtitleComponent: this.props.subtitleComponent || null,
+				subtitleError: this.props.subtitleError || "Please try again",
+				textPasswordVisibleFamily: this.props.textPasswordVisibleFamily,
+				textPasswordVisibleSize: this.props.textPasswordVisibleSize,
+				titleAttemptFailed:
+					this.props.titleAttemptFailed || "Incorrect PIN Code",
+				titleComponent: this.props.titleComponent || null,
+				titleConfirmFailed:
+					this.props.titleConfirmFailed || "Your entries did not match",
+				vibrationEnabled: this.props.vibrationEnabled,
+				delayBetweenAttempts: this.props.delayBetweenAttempts,
+				callbackError: this.props.callbackError,
+			})
+		);
+	}
 }
 PinCodeEnter.defaultProps = {
-    passcodeFallback: true,
-    styleContainer: null,
+	passcodeFallback: true,
+	styleContainer: null,
 };
 const styles = react_native_1.StyleSheet.create({
-    container: {
-        flex: 1,
-        justifyContent: "center",
-        alignItems: "center",
-    },
+	container: {
+		flex: 1,
+		justifyContent: "center",
+		alignItems: "center",
+	},
 });
 exports.default = PinCodeEnter;

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "dependencies": {
     "@react-native-community/async-storage": "^1.7.1",
     "d3-ease": "^1.0.3",
+    "expo-local-authentication": "^13.0.2",
     "lodash": "^4.17.5",
     "react-move": "^2.7.0",
     "react-native-easy-grid": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -1,62 +1,61 @@
 {
-  "name": "@haskkor/react-native-pincode",
-  "version": "1.22.6",
-  "description": "React native PIN code component",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "scripts": {
-    "dev": "yarn build -watch",
-    "build": "tsc",
-    "compile": "npm run build",
-    "addlocal": "yarn add file:./local_modules/react-native-pincode",
-    "test": "jest",
-    "pretty": "prettier --single-quote --no-semi --jsx-bracket-same-line --write \"src/**/*.{ts, tsx}\""
-  },
-  "jest": {
-    "preset": "react-native"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Haskkor/react-native-pincode.git"
-  },
-  "author": "Jeremy Farnault",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/Haskkor/react-native-pincode/issues"
-  },
-  "homepage": "https://github.com/Haskkor/react-native-pincode#readme",
-  "devDependencies": {
-    "@types/d3-ease": "^1.0.7",
-    "@types/lodash": "^4.14.104",
-    "@types/react": "^16.0.40",
-    "@types/react-native": "^0.52.16",
-    "@types/react-native-vector-icons": "^4.4.3",
-    "babel": "^6.23.0",
-    "babel-jest": "^23.4.0",
-    "enzyme": "^3.3.0",
-    "jest": "^23.3",
-    "jest-serializer-enzyme": "^1.0.0",
-    "prettier": "^1.13.7",
-    "react": "^16.2.0",
-    "react-addons-test-utils": "^15.6.2",
-    "react-dom": "^16.4.1",
-    "react-native": "^0.54.2",
-    "react-test-renderer": "^16.4.1",
-    "typescript": "^2.7.2"
-  },
-  "dependencies": {
-    "@react-native-community/async-storage": "^1.7.1",
-    "d3-ease": "^1.0.3",
-    "expo-local-authentication": "^13.0.2",
-    "lodash": "^4.17.5",
-    "react-move": "^2.7.0",
-    "react-native-easy-grid": "^0.2.2",
-    "react-native-keychain": "^6.1.1",
-    "react-native-touch-id": "^4.4.1",
-    "react-native-vector-icons": "^7.0.0"
-  },
-  "peerDependencies": {
-    "react": "*",
-    "react-native": "*"
-  }
+    "name": "@haskkor/react-native-pincode",
+    "version": "1.22.6",
+    "description": "React native PIN code component",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "scripts": {
+        "dev": "yarn build -watch",
+        "build": "tsc",
+        "compile": "npm run build",
+        "addlocal": "yarn add file:./local_modules/react-native-pincode",
+        "test": "jest",
+        "pretty": "prettier --single-quote --no-semi --jsx-bracket-same-line --write \"src/**/*.{ts, tsx}\""
+    },
+    "jest": {
+        "preset": "react-native"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/Haskkor/react-native-pincode.git"
+    },
+    "author": "Jeremy Farnault",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/Haskkor/react-native-pincode/issues"
+    },
+    "homepage": "https://github.com/Haskkor/react-native-pincode#readme",
+    "devDependencies": {
+        "@types/d3-ease": "^1.0.7",
+        "@types/lodash": "^4.14.104",
+        "@types/react": "^16.0.40",
+        "@types/react-native": "^0.52.16",
+        "@types/react-native-vector-icons": "^4.4.3",
+        "babel": "^6.23.0",
+        "babel-jest": "^23.4.0",
+        "enzyme": "^3.3.0",
+        "jest": "^23.3",
+        "jest-serializer-enzyme": "^1.0.0",
+        "prettier": "^1.13.7",
+        "react": "^16.2.0",
+        "react-addons-test-utils": "^15.6.2",
+        "react-dom": "^16.4.1",
+        "react-native": "^0.54.2",
+        "react-test-renderer": "^16.4.1",
+        "typescript": "^2.7.2"
+    },
+    "dependencies": {
+        "@react-native-community/async-storage": "^1.7.1",
+        "d3-ease": "^1.0.3",
+        "expo-local-authentication": "^13.0.2",
+        "lodash": "^4.17.5",
+        "react-move": "^2.7.0",
+        "react-native-easy-grid": "^0.2.2",
+        "react-native-keychain": "^6.1.1",
+        "react-native-vector-icons": "^7.0.0"
+    },
+    "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+    }
 }

--- a/src/PinCodeEnter.tsx
+++ b/src/PinCodeEnter.tsx
@@ -12,7 +12,7 @@ import {
 	ViewStyle,
 } from "react-native";
 import * as Keychain from "react-native-keychain";
-import TouchID from "react-native-touch-id";
+import * as LocalAuthentication from "expo-local-authentication";
 
 /**
  * Pin Code Enter PIN Page
@@ -145,16 +145,15 @@ class PinCodeEnter extends React.PureComponent<IProps, IState> {
 	}
 
 	triggerTouchID() {
-		!!TouchID &&
-			TouchID.isSupported()
-				.then(() => {
-					setTimeout(() => {
-						this.launchTouchID();
-					});
-				})
-				.catch((error: any) => {
-					console.warn("TouchID error", error);
+		LocalAuthentication.hasHardwareAsync()
+			.then(() => {
+				setTimeout(() => {
+					this.launchTouchID();
 				});
+			})
+			.catch((error: any) => {
+				console.warn("TouchID error", error);
+			});
 	}
 
 	endProcess = async (pinCode?: string) => {
@@ -215,23 +214,25 @@ class PinCodeEnter extends React.PureComponent<IProps, IState> {
 	};
 
 	async launchTouchID() {
-		const optionalConfigObject = {
-			imageColor: "#e00606",
-			imageErrorColor: "#ff0000",
-			sensorDescription: "Touch sensor",
-			sensorErrorDescription: "Failed",
-			cancelText: this.props.textCancelButtonTouchID || "Cancel",
-			fallbackLabel: "Show Passcode",
-			unifiedErrors: false,
-			passcodeFallback: this.props.passcodeFallback,
-		};
+		// const optionalConfigObject = {
+		// 	imageColor: "#e00606",
+		// 	imageErrorColor: "#ff0000",
+		// 	sensorDescription: "Touch sensor",
+		// 	sensorErrorDescription: "Failed",
+		// 	cancelText: this.props.textCancelButtonTouchID || "Cancel",
+		// 	fallbackLabel: "Show Passcode",
+		// 	unifiedErrors: false,
+		// 	passcodeFallback: this.props.passcodeFallback,
+		// };
 		try {
-			await TouchID.authenticate(
-				this.props.touchIDSentence,
-				Object.assign({}, optionalConfigObject, {
-					title: this.props.touchIDTitle,
-				})
-			).then((success: any) => {
+			await LocalAuthentication.authenticateAsync({
+				promptMessage: this.props.touchIDSentence,
+				fallbackLabel: "Show Passcode",
+				cancelLabel: this.props.textCancelButtonTouchID || "Cancel",
+				// Object.assign({}, optionalConfigObject, {
+				// 	title: this.props.touchIDTitle,
+				// })
+			}).then((success: any) => {
 				this.endProcess(this.props.storedPin || this.keyChainResult);
 			});
 		} catch (e) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2431,6 +2431,13 @@ expect@^23.6.0:
     jest-message-util "^23.4.0"
     jest-regex-util "^23.3.0"
 
+expo-local-authentication@^13.0.2:
+  version "13.0.2"
+  resolved "https://registry.yarnpkg.com/expo-local-authentication/-/expo-local-authentication-13.0.2.tgz#a785e589119538e0c328b65c0f63e162a423ad5f"
+  integrity sha512-YqyIix9+oyBbJ8Wgp/ZBQBbWbo4FMVWWibyOhrUfyx9wwRiElAlJZ52ne6XzcJEjLOSqCy4/xkhhC5LJtbnGTw==
+  dependencies:
+    invariant "^2.2.4"
+
 extend-shallow@^1.1.2:
   version "1.1.4"
   resolved "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5087,11 +5087,6 @@ react-native-keychain@^6.1.1:
   resolved "https://registry.npmjs.org/react-native-keychain/-/react-native-keychain-6.1.1.tgz"
   integrity sha512-WYvAg7FbYPyX8jJ1rY/IQGS+6zK5LtNMRa3E8x1n0M5Lmsm/9CHtakzbmqT+rLvFE7DpPBg7qFawMuUoDjjtYA==
 
-react-native-touch-id@^4.4.1:
-  version "4.4.1"
-  resolved "https://registry.npmjs.org/react-native-touch-id/-/react-native-touch-id-4.4.1.tgz"
-  integrity sha512-1jTl8fC+0fxvqegy/XXTyo6vMvPhjzkoDdaqoYZx0OH8AT250NuXnNPyKktvigIcys3+2acciqOeaCall7lrvg==
-
 react-native-vector-icons@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/react-native-vector-icons/-/react-native-vector-icons-7.0.0.tgz"


### PR DESCRIPTION
This PR changes `react-native-touch-id` library to `expo-local-authentication` in order to use biometrics